### PR TITLE
Allow setting verify flag for ClickHouse client

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Houseplant uses the following environment variables to connect to your ClickHous
 - `CLICKHOUSE_DB`: Database name (default: "development")
 - `CLICKHOUSE_USER`: Username for authentication (default: "default")
 - `CLICKHOUSE_PASSWORD`: Password for authentication (default: "")
+- `CLICKHOUSE_SECURE`: Enable secure connection via the `secure` flag of ClickHouse client (default: False)
+- `CLICKHOUSE_VERIFY`: Enable certificate verifiaction `verify` flag of ClickHouse client (default: False)
 
 ## Contributing
 

--- a/src/houseplant/clickhouse_client.py
+++ b/src/houseplant/clickhouse_client.py
@@ -61,6 +61,10 @@ class ClickHouseClient:
         self.secure = self.secure in ("true", "t", "yes", "y", "1")
         self.port = 9440 if self.secure else self.port
 
+        # Disable verification unless specified otherwise
+        self.verify = os.getenv("CLICKHOUSE_VERIFY", "n").lower()
+        self.verify = self.verify in ("true", "t", "yes", "y", "1")
+
         self.client = Client(
             host=self.host,
             port=self.port,
@@ -68,7 +72,7 @@ class ClickHouseClient:
             user=self.user,
             password=self.password,
             secure=self.secure,
-            verify=False,
+            verify=self.verify,
         )
 
         self._cluster = None


### PR DESCRIPTION
Set the `CLICKHOUSE_VERIFY` environment variable (`True/true, T/t, Yes/yes, Y/y, 1`) to enable certificate verification.
