### PR TITLE
fix(clickhouse_client): support all table engines in schema generation

### DIFF
--- a/src/houseplant/clickhouse_client.py
+++ b/src/houseplant/clickhouse_client.py
@@ -199,7 +199,6 @@ class ClickHouseClient:
                 name
             FROM system.tables
             WHERE database = currentDatabase()
-                AND position('MergeTree' IN engine) > 0
                 AND engine NOT IN ('MaterializedView', 'Dictionary')
                 AND name != 'schema_migrations'
             ORDER BY name


### PR DESCRIPTION
Remove MergeTree-only filter from `get_database_tables()` to include tables with other engine types (S3, File, etc.) in schema.sql output.

Previously, the query filtered tables to only include those with 'MergeTree' in the engine name using:
```sql
  AND position('MergeTree' IN engine) > 0
```
This caused S3 tables and other non-MergeTree engines to be excluded from schema.sql generation, even though they were valid tables that should be tracked.

The fix removes this restrictive filter while still excluding MaterializedView and Dictionary engines, which have their own dedicated methods.

Fixes schema.sql generation for S3-backed tables and other engine types.