### PR TITLE
Add database field support to migrations

### DIFF
--- a/src/houseplant/clickhouse_client.py
+++ b/src/houseplant/clickhouse_client.py
@@ -192,38 +192,41 @@ class ClickHouseClient:
         """)
         return result[0][0] if result else None
 
-    def get_database_tables(self):
+    def get_database_tables(self, database=None):
         """Get the database tables with their engines, indexes and partitioning."""
-        return self.client.execute("""
+        database_expr = f"'{database}'" if database else "currentDatabase()"
+        return self.client.execute(f"""
             SELECT
                 name
             FROM system.tables
-            WHERE database = currentDatabase()
+            WHERE database = {database_expr}
                 AND position('MergeTree' IN engine) > 0
                 AND engine NOT IN ('MaterializedView', 'Dictionary')
                 AND name != 'schema_migrations'
             ORDER BY name
         """)
 
-    def get_database_materialized_views(self):
+    def get_database_materialized_views(self, database=None):
         """Get the database materialized views."""
-        return self.client.execute("""
+        database_expr = f"'{database}'" if database else "currentDatabase()"
+        return self.client.execute(f"""
             SELECT
                 name
             FROM system.tables
-            WHERE database = currentDatabase()
+            WHERE database = {database_expr}
                 AND engine = 'MaterializedView'
                 AND name != 'schema_migrations'
             ORDER BY name
         """)
 
-    def get_database_dictionaries(self):
+    def get_database_dictionaries(self, database=None):
         """Get the database dictionaries."""
-        return self.client.execute("""
+        database_expr = f"'{database}'" if database else "currentDatabase()"
+        return self.client.execute(f"""
             SELECT
                 name
             FROM system.tables
-            WHERE database = currentDatabase()
+            WHERE database = {database_expr}
                 AND engine = 'Dictionary'
                 AND name != 'schema_migrations'
             ORDER BY name


### PR DESCRIPTION
Allow migrations to specify which database tables should be created in by adding an optional `database` field to migration YAML files.

Changes:
- Extract `database` field from migration files in migrate_up() and migrate_down()
- Add `database` to format_args for SQL template substitution
- Update database query methods to accept optional database parameter
- Modify update_schema() to query correct databases and use qualified table names
- Include database field in generated migration template (commented out)

The database field is optional and defaults to the current database connection (CLICKHOUSE_DB) when not specified, maintaining backward compatibility.

This enables creating tables in different databases within the same ClickHouse instance, addressing the limitation where all tables were created in the default database.